### PR TITLE
remove allowedLogins

### DIFF
--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -91,7 +91,6 @@ export const privyConfig: PrivyClientConfig = {
     requireUserPasswordOnCreate: true,
     noPromptOnSignature: true,
   },
-  loginMethods: ['email', 'sms', 'twitter', 'google', 'apple'],
   appearance: {
     theme: '#28283c',
   },


### PR DESCRIPTION
We don't need these because they are set directly in the dashboard, and we want to allow logins for all the options