### PR TITLE
add flag for attempted OAuth

### DIFF
--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -137,29 +137,22 @@ export const useWalletConnection = () => {
 
       const walletConnection = getWalletConnection({ walletType });
 
-      console.log(selectedWalletType);
-
       try {
         if (!walletConnection) {
           throw new Error('Onboarding: No wallet connection found.');
         } else if (walletConnection.type === WalletConnectionType.Email) {
         } else if (walletConnection.type === WalletConnectionType.OAuth) {
           if (!isConnectedWagmi && ready && !authenticated) {
-            if (attemptedOAuth) {
-              dispatch(setAttemptedOAuth(false));
-              return {};
-            } else {
-              const provider = wallets[walletType].oAuthProvider;
-              if (provider) {
-                dispatch(setAttemptedOAuth(true));
-                try {
-                  await initOAuth({
-                    provider,
-                  });
-                } catch (error) {
-                  setSelectedWalletError(error.message);
-                  log('useWalletConnection/connectWallet', error);
-                }
+            const provider = wallets[walletType].oAuthProvider;
+            if (provider) {
+              dispatch(setAttemptedOAuth(true));
+              try {
+                await initOAuth({
+                  provider,
+                });
+              } catch (error) {
+                setSelectedWalletError(error.message);
+                log('useWalletConnection/connectWallet', error);
               }
             }
           }

--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -45,7 +45,7 @@ class TestFlags {
   }
 
   get displaySocialLogin() {
-    return !!this.queryParams.displaySocialLogin;
+    return !!this.queryParams.displaySocialLogin || true;
   }
 
   get displayEmailLogin() {

--- a/src/state/account.ts
+++ b/src/state/account.ts
@@ -27,6 +27,7 @@ export type AccountState = {
   tradingRewards?: TradingRewards;
   wallet?: Nullable<Wallet>;
   walletType?: WalletType;
+  attemptedOAuth?: boolean;
 
   subaccount?: Nullable<Subaccount>;
   fills?: SubaccountFills;
@@ -168,6 +169,10 @@ export const accountSlice = createSlice({
       ...state,
       wallet: action.payload,
     }),
+    setAttemptedOAuth: (state, action: PayloadAction<boolean>) => ({
+      ...state,
+      attemptedOAuth: action.payload,
+    }),
     viewedFills: (state) => {
       state.hasUnseenFillUpdates = false;
     },
@@ -206,6 +211,7 @@ export const {
   setRestrictionType,
   setSubaccount,
   setWallet,
+  setAttemptedOAuth,
   viewedFills,
   viewedOrders,
   setBalances,

--- a/src/state/accountSelectors.ts
+++ b/src/state/accountSelectors.ts
@@ -328,6 +328,12 @@ export const getIsAccountConnected = (state: RootState) =>
 
 /**
  * @param state
+ * @returns whether the user was attempted to login via an OAuth provider
+ * */
+export const getAttemptedOAuth = (state: RootState) => state.account.attemptedOAuth;
+
+/**
+ * @param state
  * @returns OnboardingGuards (Record of boolean items) to aid in determining what Onboarding Step the user is on.
  */
 export const getOnboardingGuards = (state: RootState) => state.account.onboardingGuards;


### PR DESCRIPTION
When a user cancels their OAuth login, we don't have a way to know this happened via the redirect URL. Similarly, it's possible they don't finish that flow and the user goes to DYDX on a separate tab. In these cases, we need to clear the selected wallet state.