### PR TITLE
lowercase flags

### DIFF
--- a/src/lib/testFlags.ts
+++ b/src/lib/testFlags.ts
@@ -45,11 +45,11 @@ class TestFlags {
   }
 
   get displaySocialLogin() {
-    return !!this.queryParams.displaySocialLogin;
+    return !!this.queryParams.displaysociallogin;
   }
 
   get displayEmailLogin() {
-    return !!this.queryParams.displayEmailLogin;
+    return !!this.queryParams.displayemaillogin;
   }
 }
 


### PR DESCRIPTION
came as a PR comment on the main pr. they normalize it to lowercase when setting.